### PR TITLE
Update MyAuthenticationEntryPoint.java

### DIFF
--- a/x38ShLibClasses/src/com/ejie/x38/security/MyAuthenticationEntryPoint.java
+++ b/x38ShLibClasses/src/com/ejie/x38/security/MyAuthenticationEntryPoint.java
@@ -96,15 +96,17 @@ public class MyAuthenticationEntryPoint implements AuthenticationEntryPoint,
 		
 		if (isAjax && xhrRedirectOnError ){
 			
-			url = this.getUrl(xhrUnauthorizedPage != null ? xhrUnauthorizedPage : getPerimetralSecurityWrapper().getURLLogin(originalURL , isAjax), isPortal);
+			url = this.getUrlAjax(xhrUnauthorizedPage != null ? xhrUnauthorizedPage : getPerimetralSecurityWrapper().getURLLogin(originalURL , isAjax), isPortal);
 			
 			// Se detecta si es una petición AJAX
 			httpResponse.setStatus(HttpStatus.UNAUTHORIZED.value());
 			httpResponse.setHeader("LOCATION", url);
 			
 		}else{
-		
-			url = this.getUrl(getPerimetralSecurityWrapper().getURLLogin(originalURL , isAjax), isPortal);
+			url = getPerimetralSecurityWrapper().getURLLogin(originalURL , isAjax);
+			if(isAjax){
+				url = this.getUrlAjax(url, isPortal);
+			}
 			
 			logger.info("Redirecting to next URL:" + url);
 			httpResponse.sendRedirect(url);
@@ -118,8 +120,9 @@ public class MyAuthenticationEntryPoint implements AuthenticationEntryPoint,
 	}
 
 	// Private 
-	private String getUrl(String url, boolean isPortal){
-		return isPortal ? url.concat("&R01HNoPortal=true") : url;
+	private String getUrlAjax(String url, boolean isPortal){
+		String sep = url.indexOf('?') > -1 ? "&" : "?";
+		return isPortal ? url.concat(sep).concat("R01HNoPortal=true") : url;
 	}
 	
 	// Getters & Setters


### PR DESCRIPTION
Mejora en el tratamiento de la redirección desde la página de login XLNETs a la URL de la aplicación, para aplicaciones empotradas en el portal de *euskadi.eus*.

Hasta ahora ocurría que cuando se perdía la sesión en un aplicativo empotrado en el portal, y se intentaba recargar o navegar dentro de él, se redirigía al login de XLNETS y en la URL de vuelta siempre se incluía el parámetro `R01HNoPortal=true`, provocando que los estáticos no se cargasen en la página. Se modifica la clase **MyAuthenticationEntryPoint** para que solo aplique ese parámetro cuando se trate de una petición Ajax.